### PR TITLE
temporary fix for android phones, iphone still broken probably

### DIFF
--- a/app/views/devise/passwords/new.android.haml
+++ b/app/views/devise/passwords/new.android.haml
@@ -1,0 +1,10 @@
+.container
+  .tight-wrapper
+    %h2 Doh! Forget your password?
+    %p Enter your email and we'll send you a link to make a new one.
+    = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
+      = devise_error_messages!
+      %div
+        = f.label :email
+        %br= f.email_field :email, class: 'field standart'
+      %div= f.submit "Request Link", class: 'btn-standart full-width'


### PR DESCRIPTION
Why separate android and iphone? You have an :android mimetype and probably an :iphone mimetype. They both use webkit in their browsers so you should combine them for less errors.
